### PR TITLE
Enhance filesystem access restrictions in case of sandbox security breach

### DIFF
--- a/org.b3log.siyuan.yml
+++ b/org.b3log.siyuan.yml
@@ -7,7 +7,10 @@ base-version: *runtime-version
 command: start-siyuan.sh
 finish-args:
   - --device=dri
-  - --filesystem=home
+  - --filesystem=~/SiYuan
+  - --filesystem=~/.config/siyuan
+  - --filesystem=~/.config/SiYuan
+  - --filesystem=~/.config/SiYuan-Electron
   - --share=ipc
   - --share=network
   - --socket=x11


### PR DESCRIPTION
I have referred [this code file](https://github.com/siyuan-note/siyuan/blob/master/app/electron/main.js) from SiYuan.
To allow the SiYuan to run properly, and to avoid breaking the security of the sandbox by giving the application read/write permissions to the entire home directory, SiYuan is given read/write permissions to the following directories:
- `~/SiYuan`
- `~/.config/siyuan`
- `~/.config/SiYuan`
- `~/.config/SiYuan-Electron`